### PR TITLE
Generalize RPC provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ Proof-of-concept Django app for monitoring a Uniswap V3 liquidity pool on Polygo
    ```bash
    pip install -r requirements.txt
    ```
-2. Create a `.env` file and set the required variables (`ALCHEMY_URL`, `POOL_ADDRESS`, etc).
-   Without a valid `ALCHEMY_URL` or outbound internet access the live prices will
+2. Create a `.env` file and set the required variables (`RPC_URL`, `POOL_ADDRESS`, etc).
+   `RPC_URL` should point to any Polygon RPC provider (Alchemy, Infura, etc).
+   Without a valid RPC URL or outbound internet access the live prices will
    show as `N/A`.
 3. Start the development server. Pending migrations run automatically (set
    `AUTO_MIGRATE=0` to disable):
@@ -29,7 +30,8 @@ Proof-of-concept Django app for monitoring a Uniswap V3 liquidity pool on Polygo
 
 The dashboard is available at `/` and provides a single-page interface for all
 features. Bitmart and Coinstore prices may show as `N/A` if their APIs are
-unreachable. Uniswap data likewise requires `ALCHEMY_URL` to be set correctly.
+unreachable. Uniswap data likewise requires a valid RPC URL to be set
+correctly.
 
 Authentication has been removed; anyone with access to the app URL can view the
 dashboard.
@@ -41,7 +43,7 @@ in Render using this repository and configure the following environment
 variables in the Render dashboard:
 
 - `DJANGO_SECRET_KEY` – your Django secret key
-- `ALCHEMY_URL` – Polygon RPC URL from Alchemy
+- `RPC_URL` – Polygon RPC URL (Alchemy, Infura, etc.)
 - `POOL_ADDRESS` – Uniswap V3 pool address
 - `OTP_SECRET` – base32 secret for Microsoft Authenticator login
 - `PRIVATE_KEY` – optional wallet key for write actions

--- a/services/uniswap.py
+++ b/services/uniswap.py
@@ -9,7 +9,7 @@ from typing import Dict, Optional
 
 from web3 import Web3
 
-ALCHEMY_URL = os.environ.get("ALCHEMY_URL")
+RPC_URL = os.environ.get("RPC_URL") or os.environ.get("ALCHEMY_URL")
 POOL_ADDRESS = os.environ.get("POOL_ADDRESS")
 if POOL_ADDRESS:
     POOL_ADDRESS = Web3.to_checksum_address(POOL_ADDRESS)
@@ -36,10 +36,10 @@ POOL_ABI = [
 
 
 web3: Optional[Web3] = None
-if ALCHEMY_URL:
-    web3 = Web3(Web3.HTTPProvider(ALCHEMY_URL))
+if RPC_URL:
+    web3 = Web3(Web3.HTTPProvider(RPC_URL))
 else:  # pragma: no cover - runtime check
-    logging.warning("ALCHEMY_URL not configured; Uniswap data disabled")
+    logging.warning("RPC_URL not configured; Uniswap data disabled")
 
 
 @lru_cache(maxsize=1)


### PR DESCRIPTION
## Summary
- allow the Uniswap service to use any RPC URL by reading `RPC_URL` (falls back to `ALCHEMY_URL`)
- update README to document the generic `RPC_URL` variable

## Testing
- `python -m pip install -r requirements.txt`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6885ce3f91e88328b0bcf264bdf954ec