### PR TITLE
Add live price API using Web3

### DIFF
--- a/amm_controller/urls.py
+++ b/amm_controller/urls.py
@@ -34,4 +34,9 @@ urlpatterns = [
         views.api_coinstore_price,
         name="api_coinstore_price",
     ),
+    path(
+        "api/live_prices/",
+        views.api_live_prices,
+        name="api_live_prices",
+    ),
 ]

--- a/dashboard/templates/dashboard.html
+++ b/dashboard/templates/dashboard.html
@@ -52,19 +52,24 @@
 <script>
 
 function loadData(){
-  fetch('/api/latest/')
+  fetch('/api/live_prices/')
     .then(r=>r.json())
     .then(data=>{
       document.getElementById('uni-price').innerText = data.uniswap_price != null ? data.uniswap_price.toFixed(6) : 'N/A';
       document.getElementById('bm-price').innerText = data.bitmart_price ?? 'N/A';
       document.getElementById('cs-price').innerText = data.coinstore_price ?? 'N/A';
-
-
+    })
+    .catch(err=>{
+      console.error('Failed to load live prices:', err);
+    });
+  fetch('/api/latest/')
+    .then(r=>r.json())
+    .then(data=>{
       const ts = new Date(data.timestamp);
       document.getElementById('last-sync').innerText = ts.toLocaleString();
     })
     .catch(err=>{
-      console.error('Failed to load latest:', err);
+      console.error('Failed to load latest snapshot:', err);
     });
   fetch('/api/opportunities/')
     .then(r=>r.json())

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -11,6 +11,7 @@ from django.views.decorators.http import require_POST
 
 from .models import OpportunityLog, PriceSnapshot
 from services.uniswap import get_pool_data
+from services.uniswap_web3 import get_uniswap_price as get_live_uniswap_price
 from services.cex_price import (
     fetch_bitmart_price,
     fetch_coinstore_price,
@@ -129,3 +130,18 @@ def api_coinstore_price(request: HttpRequest) -> JsonResponse:
 
     price = fetch_coinstore_price()
     return JsonResponse({"price": price})
+
+
+def api_live_prices(request: HttpRequest) -> JsonResponse:
+    """Return current prices from each source without using the DB."""
+
+    uni = get_live_uniswap_price()
+    bm = fetch_bitmart_price()
+    cs = fetch_coinstore_price()
+    return JsonResponse(
+        {
+            "uniswap_price": uni,
+            "bitmart_price": bm,
+            "coinstore_price": cs,
+        }
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ apscheduler
 python-dotenv
 gunicorn
 whitenoise
+web3

--- a/services/cex_price.py
+++ b/services/cex_price.py
@@ -32,10 +32,15 @@ def fetch_bitmart_price() -> Optional[float]:
         tickers = data.get("data")
         if isinstance(tickers, dict):
             tickers = tickers.get("tickers")
-        if isinstance(tickers, list) and tickers:
-            ticker = tickers[0]
-            if isinstance(ticker, dict) and "last_price" in ticker:
-                return float(ticker["last_price"])
+
+        if isinstance(tickers, list):
+            for t in tickers:
+                # Handle both dict and list formats returned by the API
+                if isinstance(t, dict):
+                    if t.get("symbol") == "SHARP_USDT" and t.get("last_price") is not None:
+                        return float(t["last_price"])
+                elif isinstance(t, list) and len(t) >= 2 and t[0] == "SHARP_USDT":
+                    return float(t[1])
     except (ValueError, json.JSONDecodeError, TypeError) as exc:
         logging.warning("Failed to parse Bitmart response: %s", exc)
     return None

--- a/services/uniswap_web3.py
+++ b/services/uniswap_web3.py
@@ -1,0 +1,51 @@
+"""Get Uniswap pool price via Web3."""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from web3 import Web3
+
+# Minimal ABI containing the slot0 view we need
+UNISWAP_V3_POOL_ABI = [
+    {
+        "inputs": [],
+        "name": "slot0",
+        "outputs": [
+            {"internalType": "uint160", "name": "sqrtPriceX96", "type": "uint160"},
+            {"internalType": "int24", "name": "tick", "type": "int24"},
+            {"internalType": "uint16", "name": "observationIndex", "type": "uint16"},
+            {"internalType": "uint16", "name": "observationCardinality", "type": "uint16"},
+            {"internalType": "uint16", "name": "observationCardinalityNext", "type": "uint16"},
+            {"internalType": "uint8", "name": "feeProtocol", "type": "uint8"},
+            {"internalType": "bool", "name": "unlocked", "type": "bool"},
+        ],
+        "stateMutability": "view",
+        "type": "function",
+    }
+]
+
+ALCHEMY_URL = os.environ.get("ALCHEMY_URL")
+POOL_ADDRESS = (
+    os.environ.get("UNISWAP_POOL_ADDRESS")
+    or os.environ.get("POOL_ADDRESS")
+)
+
+
+def get_uniswap_price() -> Optional[float]:
+    """Return SHARP/USDT price from Uniswap via Web3 or ``None`` on failure."""
+    if not ALCHEMY_URL or not POOL_ADDRESS:
+        return None
+    try:
+        web3 = Web3(Web3.HTTPProvider(ALCHEMY_URL))
+        pool = web3.eth.contract(
+            address=Web3.to_checksum_address(POOL_ADDRESS),
+            abi=UNISWAP_V3_POOL_ABI,
+        )
+        slot0 = pool.functions.slot0().call()
+        sqrt_price_x96 = slot0[0]
+        price = (sqrt_price_x96 / 2**96) ** 2
+        return 1 / price if price else None
+    except Exception:
+        return None


### PR DESCRIPTION
## Summary
- fetch Uniswap price directly via Web3
- expose new `/api/live_prices/` endpoint
- update dashboard to use live pricing
- add `web3` dependency
- fix Bitmart price parsing

## Testing
- `python manage.py check`
- `python manage.py runserver 0.0.0.0:8000` *(started then stopped)*
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68874f43381083289ac0ac0d16bb8324